### PR TITLE
Enhance Sofia TikTok radar internal dashboard

### DIFF
--- a/src/app/admin/tiktok-radar/[id]/idea/page.tsx
+++ b/src/app/admin/tiktok-radar/[id]/idea/page.tsx
@@ -38,9 +38,14 @@ export default async function TikTokRadarIdeaPage({
           <p style={subTextStyle}>市場データからTikTok投稿の入口を生成します。</p>
         </div>
 
-        <Link href="/admin/tiktok-radar" style={linkStyle}>
-          一覧へ戻る
-        </Link>
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+          <Link href={`/admin/tiktok-radar/${id}/edit`} style={secondaryLinkStyle}>
+            元データを編集
+          </Link>
+          <Link href="/admin/tiktok-radar" style={linkStyle}>
+            一覧へ戻る
+          </Link>
+        </div>
       </div>
 
       <section style={summaryStyle}>
@@ -53,11 +58,27 @@ export default async function TikTokRadarIdeaPage({
           <div style={valueStyle}>{data.keyword || "-"}</div>
         </div>
         <div>
-          <div style={labelStyle}>合計スコア</div>
+          <div style={labelStyle}>共鳴合計</div>
           <div style={valueStyle}>
             {idea.totalScore}点 / {idea.scoreLabel}
           </div>
         </div>
+        <div>
+          <div style={labelStyle}>Mu導線</div>
+          <div style={valueStyle}>{idea.muLeadScore} / 20</div>
+        </div>
+        <div>
+          <div style={labelStyle}>TikTok形式</div>
+          <div style={valueStyle}>{idea.viralFormatScore} / 5</div>
+        </div>
+      </section>
+
+      <section style={strategyStyle}>
+        <div>
+          <div style={strategyLabelStyle}>Sofia 推奨アクション</div>
+          <p style={strategyTextStyle}>{idea.recommendedAction}</p>
+        </div>
+        <IdeaBlock title="Sofia戦略メモ" text={idea.sofiaStrategyNote} compact />
       </section>
 
       <section style={sectionStyle}>
@@ -152,6 +173,13 @@ const linkStyle: CSSProperties = {
   fontWeight: 700,
 };
 
+const secondaryLinkStyle: CSSProperties = {
+  ...linkStyle,
+  background: "#fff",
+  color: "#111",
+  border: "1px solid #ddd",
+};
+
 const errorStyle: CSSProperties = {
   color: "#b00020",
   fontWeight: 700,
@@ -159,7 +187,7 @@ const errorStyle: CSSProperties = {
 
 const summaryStyle: CSSProperties = {
   display: "grid",
-  gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+  gridTemplateColumns: "repeat(5, minmax(0, 1fr))",
   gap: 16,
   padding: 20,
   borderRadius: 18,
@@ -177,6 +205,28 @@ const labelStyle: CSSProperties = {
 const valueStyle: CSSProperties = {
   fontSize: 18,
   fontWeight: 900,
+};
+
+const strategyStyle: CSSProperties = {
+  padding: 20,
+  borderRadius: 18,
+  background: "#111",
+  color: "#fff",
+  marginBottom: 24,
+};
+
+const strategyLabelStyle: CSSProperties = {
+  color: "#d8c39b",
+  fontSize: 13,
+  fontWeight: 900,
+  marginBottom: 8,
+};
+
+const strategyTextStyle: CSSProperties = {
+  margin: 0,
+  fontSize: 18,
+  fontWeight: 900,
+  lineHeight: 1.7,
 };
 
 const sectionStyle: CSSProperties = {

--- a/src/app/admin/tiktok-radar/page.tsx
+++ b/src/app/admin/tiktok-radar/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { CSSProperties } from "react";
 import {
   sofiaTikTokSupabase,
   type TikTokMarketResearch,
@@ -6,9 +7,154 @@ import {
 
 type PageSearchParams = Record<string, string | string[] | undefined>;
 
+type RadarWordRank = {
+  word: string;
+  count: number;
+};
+
 function getParam(params: PageSearchParams, key: string) {
   const value = params[key];
   return Array.isArray(value) ? value[0] ?? "" : value ?? "";
+}
+
+function scoreNumber(value: number | string | null | undefined) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function totalScore(item: TikTokMarketResearch) {
+  return (
+    scoreNumber(item.why_known_score) +
+    scoreNumber(item.resonance_score) +
+    scoreNumber(item.save_intent_score)
+  );
+}
+
+function muLeadScore(item: TikTokMarketResearch) {
+  const text = [
+    item.category,
+    item.keyword,
+    item.hook_text,
+    item.caption_text,
+    item.top_comment,
+    item.reaction_words,
+    item.resonance_words,
+    item.sofia_note,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const base = totalScore(item);
+  const hasMuAngle =
+    text.includes("なんで") ||
+    text.includes("見抜") ||
+    text.includes("本当は") ||
+    text.includes("相手の気持ち") ||
+    text.includes("自己否定") ||
+    text.includes("苦しい");
+  const hasSaveIntent = text.includes("保存") || text.includes("見返す");
+
+  return Math.min(20, base + (hasMuAngle ? 3 : 0) + (hasSaveIntent ? 2 : 0));
+}
+
+function engagementRate(item: TikTokMarketResearch) {
+  const views = scoreNumber(item.views_count);
+  if (views <= 0) return 0;
+
+  return (
+    ((scoreNumber(item.likes_count) +
+      scoreNumber(item.comments_count) +
+      scoreNumber(item.shares_count) +
+      scoreNumber(item.saves_count)) /
+      views) *
+    100
+  );
+}
+
+function formatPercent(value: number) {
+  if (!Number.isFinite(value) || value <= 0) return "-";
+  return `${value.toFixed(value >= 10 ? 0 : 1)}%`;
+}
+
+function pickTopItems(items: TikTokMarketResearch[], count: number) {
+  return [...items]
+    .sort((a, b) => muLeadScore(b) - muLeadScore(a))
+    .slice(0, count);
+}
+
+function countByStatus(items: TikTokMarketResearch[]) {
+  return items.reduce<Record<string, number>>((acc, item) => {
+    const status = item.status || "draft";
+    acc[status] = (acc[status] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
+function splitRadarWords(value: string | null | undefined) {
+  return (value ?? "")
+    .split(/[\/\n,、。\s]+/)
+    .map((word) => word.trim())
+    .filter((word) => word.length >= 2);
+}
+
+function rankWords(items: TikTokMarketResearch[], key: "reaction_words" | "resonance_words") {
+  const counts = new Map<string, number>();
+
+  for (const item of items) {
+    for (const word of splitRadarWords(item[key])) {
+      counts.set(word, (counts.get(word) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .map(([word, count]) => ({ word, count }))
+    .sort((a, b) => b.count - a.count || a.word.localeCompare(b.word))
+    .slice(0, 8);
+}
+
+function buildSofiaSummary(items: TikTokMarketResearch[]) {
+  if (items.length === 0) {
+    return "まだ市場データがありません。まずはTikTok URLを一括登録して、Sofiaが読める素材を増やしてください。";
+  }
+
+  const top = pickTopItems(items, 1)[0];
+  const resonanceWords = rankWords(items, "resonance_words")
+    .slice(0, 3)
+    .map((item) => item.word)
+    .join(" / ");
+  const draftCount = items.filter((item) => (item.status || "draft") === "draft").length;
+
+  return [
+    top
+      ? `今日の最優先素材は「${top.keyword || top.category || "未分類"}」です。Mu導線スコアが高く、投稿案化に向いています。`
+      : "今日の最優先素材はまだありません。",
+    resonanceWords
+      ? `いま強い共鳴語は ${resonanceWords} です。`
+      : "共鳴語はまだ十分に蓄積されていません。",
+    draftCount > 0
+      ? `未分析・下書き素材が ${draftCount} 件あります。まず上位候補だけ投稿案へ回すと効率的です。`
+      : "下書き素材は整理されています。winner/good から投稿化を進められます。",
+  ].join("\n");
+}
+
+function buildWorkFeed(items: TikTokMarketResearch[]) {
+  const statusCounts = countByStatus(items);
+  const topMuLead = pickTopItems(items, 3);
+  const saveCandidates = [...items]
+    .sort((a, b) => scoreNumber(b.save_intent_score) - scoreNumber(a.save_intent_score))
+    .slice(0, 3);
+
+  const feed = [
+    `登録素材: ${items.length}件 / winner: ${statusCounts.winner ?? 0}件 / good: ${statusCounts.good ?? 0}件 / draft: ${statusCounts.draft ?? 0}件`,
+    topMuLead.length > 0
+      ? `Mu導線候補: ${topMuLead.map((item) => item.keyword || item.category || "未分類").join(" / ")}`
+      : "Mu導線候補: まだありません",
+    saveCandidates.length > 0
+      ? `保存型に向く素材: ${saveCandidates.map((item) => item.keyword || item.category || "未分類").join(" / ")}`
+      : "保存型に向く素材: まだありません",
+  ];
+
+  return feed;
 }
 
 export default async function TikTokRadarPage({
@@ -47,64 +193,89 @@ export default async function TikTokRadarPage({
     query = query.order("resonance_score", { ascending: false });
   } else if (sort === "save") {
     query = query.order("save_intent_score", { ascending: false });
+  } else if (sort === "mu") {
+    query = query.order("why_known_score", { ascending: false });
   } else {
     query = query.order("created_at", { ascending: false });
   }
 
-  const { data, error } = await query.limit(100);
+  const [{ data, error }, { data: allData }] = await Promise.all([
+    query.limit(100),
+    sofiaTikTokSupabase
+      .from("tiktok_market_research")
+      .select("*")
+      .order("created_at", { ascending: false })
+      .limit(500),
+  ]);
+
   const items = (data ?? []) as TikTokMarketResearch[];
+  const allItems = (allData ?? items) as TikTokMarketResearch[];
+  const dashboardItems = allItems.length > 0 ? allItems : items;
+  const statusCounts = countByStatus(dashboardItems);
+  const topMuLeadItems = pickTopItems(dashboardItems, 3);
+  const resonanceWords = rankWords(dashboardItems, "resonance_words");
+  const reactionWords = rankWords(dashboardItems, "reaction_words");
+  const sofiaSummary = buildSofiaSummary(dashboardItems);
+  const workFeed = buildWorkFeed(dashboardItems);
 
   return (
-    <main style={{ padding: 24, maxWidth: 1100, margin: "0 auto" }}>
+    <main style={{ padding: 24, maxWidth: 1180, margin: "0 auto" }}>
       <div style={{ display: "flex", justifyContent: "space-between", gap: 16 }}>
         <div>
           <h1 style={{ fontSize: 28, fontWeight: 700 }}>
             Sofia TikTok市場レーダー
           </h1>
           <p style={{ marginTop: 8, color: "#666" }}>
-            TikTok市場動画の冒頭フック、反応語、共鳴語を蓄積します。
+            TikTok市場動画の冒頭フック、反応語、共鳴語を蓄積し、Muverse投稿導線へ変換します。
           </p>
         </div>
 
         <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
-          <Link
-            href="/admin/tiktok-radar/bulk"
-            style={{
-              height: 44,
-              padding: "0 18px",
-              borderRadius: 10,
-              background: "#fff",
-              color: "#111",
-              border: "1px solid #ddd",
-              textDecoration: "none",
-              display: "inline-flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontWeight: 700,
-            }}
-          >
+          <Link href="/admin/tiktok-radar/bulk" style={secondaryButtonStyle}>
             URL一括登録
           </Link>
 
-          <Link
-            href="/admin/tiktok-radar/new"
-            style={{
-              height: 44,
-              padding: "0 18px",
-              borderRadius: 10,
-              background: "#111",
-              color: "#fff",
-              textDecoration: "none",
-              display: "inline-flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontWeight: 700,
-            }}
-          >
+          <Link href="/admin/tiktok-radar/new" style={primaryButtonStyle}>
             新規登録
           </Link>
         </div>
       </div>
+
+      <section style={radarPanelStyle}>
+        <div style={summaryHeaderStyle}>
+          <div>
+            <div style={eyebrowStyle}>Sofia 今日のレーダー</div>
+            <pre style={summaryTextStyle}>{sofiaSummary}</pre>
+          </div>
+          <div style={scoreCardStyle}>
+            <div style={scoreCardLabelStyle}>Mu導線候補</div>
+            <div style={scoreCardValueStyle}>{topMuLeadItems.length}件</div>
+            <div style={scoreCardHintStyle}>高共鳴・保存・見抜き素材</div>
+          </div>
+        </div>
+
+        <div style={metricGridStyle}>
+          <MetricCard label="登録素材" value={`${dashboardItems.length}件`} hint="全市場データ" />
+          <MetricCard label="winner" value={`${statusCounts.winner ?? 0}件`} hint="投稿化優先" />
+          <MetricCard label="good" value={`${statusCounts.good ?? 0}件`} hint="調整して投稿化" />
+          <MetricCard label="draft" value={`${statusCounts.draft ?? 0}件`} hint="未整理素材" />
+        </div>
+
+        <div style={insightGridStyle}>
+          <InsightList title="Mu導線スコア上位" items={topMuLeadItems} />
+          <WordList title="共鳴語ランキング" words={resonanceWords} />
+          <WordList title="反応語ランキング" words={reactionWords} />
+        </div>
+
+        <div style={feedStyle}>
+          <div style={feedTitleStyle}>Sofia Work Feed</div>
+          {workFeed.map((message) => (
+            <div key={message} style={feedItemStyle}>
+              {message}
+            </div>
+          ))}
+        </div>
+      </section>
 
       <form
         action="/admin/tiktok-radar"
@@ -159,47 +330,21 @@ export default async function TikTokRadarPage({
           label="並び順"
           name="sort"
           defaultValue={sort}
-          options={["new", "why", "resonance", "save"]}
+          options={["new", "why", "resonance", "save", "mu"]}
           labels={{
             new: "新しい順",
             why: "なんでスコア順",
             resonance: "共鳴スコア順",
             save: "保存意図順",
+            mu: "Mu導線候補順",
           }}
         />
 
-        <button
-          type="submit"
-          style={{
-            height: 42,
-            padding: "0 16px",
-            borderRadius: 10,
-            border: "none",
-            background: "#111",
-            color: "#fff",
-            fontWeight: 700,
-            cursor: "pointer",
-          }}
-        >
+        <button type="submit" style={primarySubmitStyle}>
           絞り込み
         </button>
 
-        <Link
-          href="/admin/tiktok-radar"
-          style={{
-            height: 42,
-            padding: "0 16px",
-            borderRadius: 10,
-            border: "1px solid #ddd",
-            background: "#fff",
-            color: "#111",
-            textDecoration: "none",
-            display: "inline-flex",
-            alignItems: "center",
-            justifyContent: "center",
-            fontWeight: 700,
-          }}
-        >
+        <Link href="/admin/tiktok-radar" style={secondarySubmitStyle}>
           解除
         </Link>
       </form>
@@ -223,24 +368,13 @@ export default async function TikTokRadarPage({
       ) : null}
 
       <section style={{ marginTop: 18 }}>
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "1fr 1.5fr 0.55fr 0.55fr 0.55fr 0.55fr 0.7fr 1fr",
-            gap: 12,
-            padding: "12px 14px",
-            borderRadius: 10,
-            background: "#f4f4f4",
-            fontWeight: 700,
-            fontSize: 13,
-          }}
-        >
+        <div style={tableHeaderStyle}>
           <div>カテゴリ</div>
           <div>冒頭フック</div>
           <div>なんで</div>
           <div>共鳴</div>
           <div>保存</div>
-          <div>合計</div>
+          <div>Mu導線</div>
           <div>状態</div>
           <div>操作</div>
         </div>
@@ -251,18 +385,7 @@ export default async function TikTokRadarPage({
           </div>
         ) : (
           items.map((item) => (
-            <article
-              key={item.id}
-              style={{
-                display: "grid",
-                gridTemplateColumns: "1fr 1.5fr 0.55fr 0.55fr 0.55fr 0.55fr 0.7fr 1fr",
-                gap: 12,
-                padding: "14px",
-                borderBottom: "1px solid #eee",
-                alignItems: "start",
-                fontSize: 14,
-              }}
-            >
+            <article key={item.id} style={tableRowStyle}>
               <div>
                 <div style={{ fontWeight: 700 }}>
                   {item.category || "未分類"}
@@ -270,72 +393,33 @@ export default async function TikTokRadarPage({
                 <div style={{ marginTop: 4, color: "#666", fontSize: 12 }}>
                   {item.keyword || "-"}
                 </div>
+                <div style={{ marginTop: 6, color: "#888", fontSize: 12 }}>
+                  反応率 {formatPercent(engagementRate(item))}
+                </div>
               </div>
 
               <div>
                 <div style={{ fontWeight: 700 }}>
                   {item.hook_text || "冒頭フック未入力"}
                 </div>
-                <a
-                  href={item.video_url}
-                  target="_blank"
-                  rel="noreferrer"
-                  style={{
-                    display: "inline-block",
-                    marginTop: 6,
-                    color: "#2563eb",
-                    fontSize: 12,
-                  }}
-                >
+                <a href={item.video_url} target="_blank" rel="noreferrer" style={externalLinkStyle}>
                   TikTokを開く
                 </a>
               </div>
 
-              <div>{item.why_known_score ?? 0}</div>
-              <div>{item.resonance_score ?? 0}</div>
-              <div>{item.save_intent_score ?? 0}</div>
+              <ScorePill value={scoreNumber(item.why_known_score)} />
+              <ScorePill value={scoreNumber(item.resonance_score)} />
+              <ScorePill value={scoreNumber(item.save_intent_score)} />
+              <ScorePill value={muLeadScore(item)} max={20} />
               <div>
-                {(item.why_known_score ?? 0) +
-                  (item.resonance_score ?? 0) +
-                  (item.save_intent_score ?? 0)}
+                <StatusBadge status={item.status || "draft"} />
               </div>
-              <div>{item.status || "draft"}</div>
               <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                <Link
-                  href={`/admin/tiktok-radar/${item.id}/idea`}
-                  style={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    minHeight: 34,
-                    padding: "6px 12px",
-                    borderRadius: 8,
-                    background: "#2563eb",
-                    color: "#fff",
-                    textDecoration: "none",
-                    fontSize: 12,
-                    fontWeight: 700,
-                  }}
-                >
+                <Link href={`/admin/tiktok-radar/${item.id}/idea`} style={ideaButtonStyle}>
                   投稿案
                 </Link>
 
-                <Link
-                  href={`/admin/tiktok-radar/${item.id}/edit`}
-                  style={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    minHeight: 34,
-                    padding: "6px 12px",
-                    borderRadius: 8,
-                    background: "#111",
-                    color: "#fff",
-                    textDecoration: "none",
-                    fontSize: 12,
-                    fontWeight: 700,
-                  }}
-                >
+                <Link href={`/admin/tiktok-radar/${item.id}/edit`} style={editButtonStyle}>
                   編集
                 </Link>
               </div>
@@ -345,6 +429,89 @@ export default async function TikTokRadarPage({
       </section>
     </main>
   );
+}
+
+function MetricCard({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <div style={metricCardStyle}>
+      <div style={metricLabelStyle}>{label}</div>
+      <div style={metricValueStyle}>{value}</div>
+      <div style={metricHintStyle}>{hint}</div>
+    </div>
+  );
+}
+
+function InsightList({ title, items }: { title: string; items: TikTokMarketResearch[] }) {
+  return (
+    <div style={insightCardStyle}>
+      <h2 style={insightTitleStyle}>{title}</h2>
+      {items.length === 0 ? (
+        <p style={emptyInsightStyle}>候補がありません。</p>
+      ) : (
+        items.map((item, index) => (
+          <Link key={item.id} href={`/admin/tiktok-radar/${item.id}/idea`} style={insightItemStyle}>
+            <span style={rankStyle}>{index + 1}</span>
+            <span>
+              <strong>{item.keyword || item.category || "未分類"}</strong>
+              <small style={insightSmallStyle}>Mu導線 {muLeadScore(item)} / 合計 {totalScore(item)}</small>
+            </span>
+          </Link>
+        ))
+      )}
+    </div>
+  );
+}
+
+function WordList({ title, words }: { title: string; words: RadarWordRank[] }) {
+  return (
+    <div style={insightCardStyle}>
+      <h2 style={insightTitleStyle}>{title}</h2>
+      {words.length === 0 ? (
+        <p style={emptyInsightStyle}>まだ十分な語がありません。</p>
+      ) : (
+        <div style={wordWrapStyle}>
+          {words.map((item) => (
+            <span key={item.word} style={wordBadgeStyle}>
+              {item.word} <small>{item.count}</small>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ScorePill({ value, max = 5 }: { value: number; max?: number }) {
+  const ratio = max > 0 ? value / max : 0;
+  const background = ratio >= 0.75 ? "#e9f8ef" : ratio >= 0.45 ? "#fff6dd" : "#f4f4f4";
+  const color = ratio >= 0.75 ? "#0f7a3b" : ratio >= 0.45 ? "#8a5c00" : "#555";
+
+  return (
+    <div style={{ ...scorePillStyle, background, color }}>
+      {value}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const background =
+    status === "winner"
+      ? "#e9f8ef"
+      : status === "good"
+        ? "#edf4ff"
+        : status === "rejected"
+          ? "#fff0f0"
+          : "#f5f5f5";
+  const color =
+    status === "winner"
+      ? "#0f7a3b"
+      : status === "good"
+        ? "#2459a6"
+        : status === "rejected"
+          ? "#b00020"
+          : "#555";
+
+  return <span style={{ ...statusBadgeStyle, background, color }}>{status}</span>;
 }
 
 function Select({
@@ -374,10 +541,307 @@ function Select({
   );
 }
 
-const fieldStyle = {
+const fieldStyle: CSSProperties = {
   height: 42,
   padding: "0 12px",
   borderRadius: 10,
   border: "1px solid #ddd",
   background: "#fff",
+};
+
+const primaryButtonStyle: CSSProperties = {
+  height: 44,
+  padding: "0 18px",
+  borderRadius: 10,
+  background: "#111",
+  color: "#fff",
+  textDecoration: "none",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontWeight: 700,
+};
+
+const secondaryButtonStyle: CSSProperties = {
+  ...primaryButtonStyle,
+  background: "#fff",
+  color: "#111",
+  border: "1px solid #ddd",
+};
+
+const primarySubmitStyle: CSSProperties = {
+  height: 42,
+  padding: "0 16px",
+  borderRadius: 10,
+  border: "none",
+  background: "#111",
+  color: "#fff",
+  fontWeight: 700,
+  cursor: "pointer",
+};
+
+const secondarySubmitStyle: CSSProperties = {
+  height: 42,
+  padding: "0 16px",
+  borderRadius: 10,
+  border: "1px solid #ddd",
+  background: "#fff",
+  color: "#111",
+  textDecoration: "none",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontWeight: 700,
+};
+
+const radarPanelStyle: CSSProperties = {
+  marginTop: 24,
+  padding: 20,
+  borderRadius: 20,
+  background: "#fffdf8",
+  border: "1px solid #eadfce",
+};
+
+const summaryHeaderStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "1fr 220px",
+  gap: 18,
+  alignItems: "stretch",
+};
+
+const eyebrowStyle: CSSProperties = {
+  fontSize: 13,
+  color: "#7a5a2c",
+  fontWeight: 900,
+  letterSpacing: "0.04em",
+};
+
+const summaryTextStyle: CSSProperties = {
+  margin: "10px 0 0",
+  whiteSpace: "pre-wrap",
+  fontFamily: "inherit",
+  lineHeight: 1.8,
+  color: "#222",
+};
+
+const scoreCardStyle: CSSProperties = {
+  padding: 18,
+  borderRadius: 16,
+  background: "#111",
+  color: "#fff",
+};
+
+const scoreCardLabelStyle: CSSProperties = {
+  fontSize: 13,
+  opacity: 0.78,
+  fontWeight: 700,
+};
+
+const scoreCardValueStyle: CSSProperties = {
+  marginTop: 8,
+  fontSize: 36,
+  fontWeight: 900,
+};
+
+const scoreCardHintStyle: CSSProperties = {
+  marginTop: 6,
+  fontSize: 12,
+  opacity: 0.75,
+};
+
+const metricGridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+  gap: 12,
+  marginTop: 18,
+};
+
+const metricCardStyle: CSSProperties = {
+  padding: 14,
+  borderRadius: 14,
+  background: "#faf8f3",
+  border: "1px solid #eee4d7",
+};
+
+const metricLabelStyle: CSSProperties = {
+  color: "#777",
+  fontSize: 12,
+  fontWeight: 800,
+};
+
+const metricValueStyle: CSSProperties = {
+  marginTop: 6,
+  fontSize: 24,
+  fontWeight: 900,
+};
+
+const metricHintStyle: CSSProperties = {
+  marginTop: 4,
+  color: "#777",
+  fontSize: 12,
+};
+
+const insightGridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "1.2fr 1fr 1fr",
+  gap: 14,
+  marginTop: 16,
+};
+
+const insightCardStyle: CSSProperties = {
+  padding: 16,
+  borderRadius: 16,
+  background: "#fff",
+  border: "1px solid #eee4d7",
+};
+
+const insightTitleStyle: CSSProperties = {
+  margin: "0 0 12px",
+  fontSize: 16,
+  fontWeight: 900,
+};
+
+const insightItemStyle: CSSProperties = {
+  display: "flex",
+  gap: 10,
+  alignItems: "flex-start",
+  padding: "10px 0",
+  color: "#111",
+  textDecoration: "none",
+  borderTop: "1px solid #f0ede7",
+};
+
+const rankStyle: CSSProperties = {
+  width: 24,
+  height: 24,
+  borderRadius: 999,
+  background: "#111",
+  color: "#fff",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontSize: 12,
+  fontWeight: 900,
+  flex: "0 0 auto",
+};
+
+const insightSmallStyle: CSSProperties = {
+  display: "block",
+  marginTop: 4,
+  color: "#777",
+  fontSize: 12,
+};
+
+const emptyInsightStyle: CSSProperties = {
+  margin: 0,
+  color: "#777",
+  fontSize: 13,
+};
+
+const wordWrapStyle: CSSProperties = {
+  display: "flex",
+  gap: 8,
+  flexWrap: "wrap",
+};
+
+const wordBadgeStyle: CSSProperties = {
+  display: "inline-flex",
+  gap: 6,
+  alignItems: "center",
+  padding: "7px 10px",
+  borderRadius: 999,
+  background: "#f6f4ef",
+  color: "#342719",
+  fontSize: 12,
+  fontWeight: 800,
+};
+
+const feedStyle: CSSProperties = {
+  marginTop: 16,
+  padding: 14,
+  borderRadius: 16,
+  background: "#f6f4ef",
+};
+
+const feedTitleStyle: CSSProperties = {
+  fontSize: 13,
+  fontWeight: 900,
+  color: "#6f5533",
+  marginBottom: 8,
+};
+
+const feedItemStyle: CSSProperties = {
+  padding: "8px 0",
+  borderTop: "1px solid #e8dfd1",
+  fontSize: 13,
+  color: "#333",
+};
+
+const tableHeaderStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "1fr 1.45fr 0.5fr 0.5fr 0.5fr 0.65fr 0.65fr 1fr",
+  gap: 12,
+  padding: "12px 14px",
+  borderRadius: 10,
+  background: "#f4f4f4",
+  fontWeight: 700,
+  fontSize: 13,
+};
+
+const tableRowStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "1fr 1.45fr 0.5fr 0.5fr 0.5fr 0.65fr 0.65fr 1fr",
+  gap: 12,
+  padding: "14px",
+  borderBottom: "1px solid #eee",
+  alignItems: "start",
+  fontSize: 14,
+};
+
+const externalLinkStyle: CSSProperties = {
+  display: "inline-block",
+  marginTop: 6,
+  color: "#2563eb",
+  fontSize: 12,
+};
+
+const scorePillStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minWidth: 34,
+  height: 30,
+  padding: "0 8px",
+  borderRadius: 999,
+  fontWeight: 900,
+};
+
+const statusBadgeStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: 28,
+  padding: "4px 10px",
+  borderRadius: 999,
+  fontSize: 12,
+  fontWeight: 900,
+};
+
+const ideaButtonStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: 34,
+  padding: "6px 12px",
+  borderRadius: 8,
+  background: "#2563eb",
+  color: "#fff",
+  textDecoration: "none",
+  fontSize: 12,
+  fontWeight: 700,
+};
+
+const editButtonStyle: CSSProperties = {
+  ...ideaButtonStyle,
+  background: "#111",
 };

--- a/src/app/api/cron/tiktok-radar-daily/route.ts
+++ b/src/app/api/cron/tiktok-radar-daily/route.ts
@@ -1,0 +1,143 @@
+// src/app/api/cron/tiktok-radar-daily/route.ts
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { sofiaTikTokSupabase, type TikTokMarketResearch } from "@/lib/sofia/tiktok-radar/supabase";
+
+function json(data: unknown, status = 200) {
+  return NextResponse.json(data, { status });
+}
+
+function isCronAuthorized(req: NextRequest): boolean {
+  const cronSecret = process.env.CRON_SECRET?.trim();
+  const authorization = req.headers.get("authorization") || req.headers.get("Authorization") || "";
+  const urlSecret = new URL(req.url).searchParams.get("secret")?.trim() || "";
+  const userAgent = req.headers.get("user-agent") || "";
+
+  if (cronSecret && (authorization === `Bearer ${cronSecret}` || urlSecret === cronSecret)) {
+    return true;
+  }
+
+  return userAgent.includes("vercel-cron/1.0");
+}
+
+function scoreNumber(value: number | null | undefined) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function totalScore(item: TikTokMarketResearch) {
+  return (
+    scoreNumber(item.why_known_score) +
+    scoreNumber(item.resonance_score) +
+    scoreNumber(item.save_intent_score)
+  );
+}
+
+function muLeadScore(item: TikTokMarketResearch) {
+  const text = [
+    item.category,
+    item.keyword,
+    item.hook_text,
+    item.caption_text,
+    item.top_comment,
+    item.reaction_words,
+    item.resonance_words,
+    item.sofia_note,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return Math.min(
+    20,
+    totalScore(item) +
+      (text.includes("なんで") || text.includes("見抜") || text.includes("本当は") ? 3 : 0) +
+      (text.includes("保存") || text.includes("見返す") ? 2 : 0)
+  );
+}
+
+function splitWords(value: string | null | undefined) {
+  return (value ?? "")
+    .split(/[\/\n,、。\s]+/)
+    .map((word) => word.trim())
+    .filter((word) => word.length >= 2);
+}
+
+function rankWords(items: TikTokMarketResearch[], key: "reaction_words" | "resonance_words") {
+  const counts = new Map<string, number>();
+
+  for (const item of items) {
+    for (const word of splitWords(item[key])) {
+      counts.set(word, (counts.get(word) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .map(([word, count]) => ({ word, count }))
+    .sort((a, b) => b.count - a.count || a.word.localeCompare(b.word))
+    .slice(0, 8);
+}
+
+function countByStatus(items: TikTokMarketResearch[]) {
+  return items.reduce<Record<string, number>>((acc, item) => {
+    const status = item.status || "draft";
+    acc[status] = (acc[status] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
+async function handle(req: NextRequest) {
+  if (!isCronAuthorized(req)) {
+    return json({ ok: false, error: "unauthorized" }, 401);
+  }
+
+  const { data, error } = await sofiaTikTokSupabase
+    .from("tiktok_market_research")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(500);
+
+  if (error) {
+    return json({ ok: false, error: "tiktok_radar_fetch_failed", detail: error.message }, 500);
+  }
+
+  const items = (data ?? []) as TikTokMarketResearch[];
+  const statusCounts = countByStatus(items);
+  const topMuLead = [...items]
+    .sort((a, b) => muLeadScore(b) - muLeadScore(a))
+    .slice(0, 5)
+    .map((item) => ({
+      id: item.id,
+      category: item.category,
+      keyword: item.keyword,
+      status: item.status || "draft",
+      total_score: totalScore(item),
+      mu_lead_score: muLeadScore(item),
+      hook_text: item.hook_text,
+      video_url: item.video_url,
+    }));
+
+  return json({
+    ok: true,
+    purpose: "Sofia TikTok radar keepalive and daily summary",
+    total_items: items.length,
+    status_counts: statusCounts,
+    top_resonance_words: rankWords(items, "resonance_words"),
+    top_reaction_words: rankWords(items, "reaction_words"),
+    top_mu_lead: topMuLead,
+    recommended_next_action:
+      topMuLead.length > 0
+        ? "上位のMu導線候補から、見抜き型・保存型・Mu導線型の順で投稿案を確認してください。"
+        : "URL一括登録で市場素材を追加してください。",
+    checked_at: new Date().toISOString(),
+  });
+}
+
+export async function GET(req: NextRequest) {
+  return handle(req);
+}
+
+export async function POST(req: NextRequest) {
+  return handle(req);
+}

--- a/src/lib/sofia/tiktok-radar/analyzer.ts
+++ b/src/lib/sofia/tiktok-radar/analyzer.ts
@@ -29,6 +29,11 @@ const reactionWordPatterns = [
   "今の私",
   "まさに",
   "わかりすぎる",
+  "鳥肌",
+  "言語化",
+  "救われた",
+  "しんどい",
+  "苦しい",
 ];
 
 const resonanceWordPatterns = [
@@ -48,6 +53,39 @@ const resonanceWordPatterns = [
   "寂しい",
   "我慢",
   "本音",
+  "未読",
+  "既読",
+  "沈黙",
+  "都合のいい人",
+  "境界線",
+  "承認欲求",
+  "依存",
+  "見捨てられ不安",
+];
+
+const saveIntentPatterns = [
+  "保存",
+  "見返す",
+  "覚えて",
+  "チェック",
+  "まとめ",
+  "特徴",
+  "サイン",
+  "理由",
+  "共通点",
+  "何度も",
+];
+
+const muLeadPatterns = [
+  "なんで",
+  "本当は",
+  "実は",
+  "見抜",
+  "気づいて",
+  "相手の気持ち",
+  "自分の価値",
+  "止まって",
+  "言葉に",
 ];
 
 function uniqueJoin(words: string[]) {
@@ -60,6 +98,10 @@ function clampScore(score: number) {
 
 function countMatches(text: string, patterns: string[]) {
   return patterns.filter((word) => text.includes(word)).length;
+}
+
+function hasAny(text: string, patterns: string[]) {
+  return patterns.some((word) => text.includes(word));
 }
 
 export function analyzeTikTokRadarInput(
@@ -77,33 +119,43 @@ export function analyzeTikTokRadarInput(
 
   const reactionHits = reactionWordPatterns.filter((word) => text.includes(word));
   const resonanceHits = resonanceWordPatterns.filter((word) => text.includes(word));
+  const saveHits = saveIntentPatterns.filter((word) => text.includes(word));
 
   const hasQuestionFeeling =
     text.includes("なぜ") ||
     text.includes("なんで") ||
     text.includes("本当は") ||
     text.includes("実は") ||
-    text.includes("気づいて");
+    text.includes("気づいて") ||
+    text.includes("見抜");
 
   const hasLoveTheme =
     text.includes("恋愛") ||
     text.includes("復縁") ||
     text.includes("片思い") ||
     text.includes("連絡") ||
-    text.includes("相手");
+    text.includes("相手") ||
+    text.includes("既読") ||
+    text.includes("未読");
 
   const hasPainTheme =
     text.includes("苦しい") ||
     text.includes("不安") ||
     text.includes("寂しい") ||
     text.includes("責め") ||
-    text.includes("我慢");
+    text.includes("我慢") ||
+    text.includes("しんどい") ||
+    text.includes("見捨てられ");
+
+  const hasMuLeadTheme = hasAny(text, muLeadPatterns);
+  const hasSaveFormat = hasAny(text, saveIntentPatterns);
 
   const reactionCount = countMatches(text, reactionWordPatterns);
   const resonanceCount = countMatches(text, resonanceWordPatterns);
+  const saveCount = countMatches(text, saveIntentPatterns);
 
   const whyScore = clampScore(
-    2 + reactionCount + (hasQuestionFeeling ? 1 : 0) + (hasPainTheme ? 1 : 0)
+    2 + reactionCount + (hasQuestionFeeling ? 1 : 0) + (hasPainTheme ? 1 : 0) + (hasMuLeadTheme ? 1 : 0)
   );
 
   const resonanceScore = clampScore(
@@ -111,10 +163,7 @@ export function analyzeTikTokRadarInput(
   );
 
   const saveScore = clampScore(
-    1 +
-      (text.includes("保存") || text.includes("見返す") ? 2 : 0) +
-      (hasPainTheme ? 1 : 0) +
-      (hasQuestionFeeling ? 1 : 0)
+    1 + saveCount + (hasSaveFormat ? 1 : 0) + (hasPainTheme ? 1 : 0) + (hasQuestionFeeling ? 1 : 0)
   );
 
   const reactionWords = uniqueJoin(
@@ -134,12 +183,15 @@ export function analyzeTikTokRadarInput(
         ]
   );
 
+  const totalScore = Number(whyScore) + Number(resonanceScore) + Number(saveScore);
   const status =
-    Number(whyScore) >= 5 || Number(resonanceScore) >= 5
+    totalScore >= 13 || Number(whyScore) >= 5 || Number(resonanceScore) >= 5
       ? "winner"
-      : Number(whyScore) >= 4 || Number(resonanceScore) >= 4
+      : totalScore >= 10 || Number(whyScore) >= 4 || Number(resonanceScore) >= 4
         ? "good"
-        : "watch";
+        : totalScore >= 7
+          ? "watch"
+          : "draft";
 
   const sofiaNote = [
     "Sofia自動分析:",
@@ -152,8 +204,15 @@ export function analyzeTikTokRadarInput(
     hasPainTheme
       ? "不安・苦しさ・自己否定に触れているため、共鳴が起きやすいです。"
       : "痛みの言語が少ないため、共鳴語を追加すると伸びやすいです。",
+    hasSaveFormat
+      ? "保存・見返しに向く構造があります。保存型投稿に展開できます。"
+      : "保存型にするなら、チェックリスト・特徴・理由の形に整えると強くなります。",
+    hasMuLeadTheme
+      ? "Mu導線に接続しやすい言葉があります。最後は“相手を当てる”ではなく“自分の止まりを映す”方向にしてください。"
+      : "Mu導線へつなぐには、内側の止まり・見落とし・言葉になっていないズレを足してください。",
     `反応語候補: ${reactionWords}`,
     `共鳴語候補: ${resonanceWords}`,
+    `保存語候補: ${uniqueJoin(saveHits.length > 0 ? saveHits : ["保存", "見返す", "チェック"])}`,
   ].join("\n");
 
   return {

--- a/src/lib/sofia/tiktok-radar/postIdea.ts
+++ b/src/lib/sofia/tiktok-radar/postIdea.ts
@@ -28,6 +28,10 @@ export type TikTokRadarPostIdea = {
   hashtags: string;
   totalScore: number;
   scoreLabel: string;
+  muLeadScore: number;
+  viralFormatScore: number;
+  recommendedAction: string;
+  sofiaStrategyNote: string;
   variants: TikTokRadarPostIdeaVariant[];
 };
 
@@ -39,12 +43,16 @@ function scoreNumber(value: number | null | undefined) {
   return Number.isFinite(Number(value)) ? Number(value) : 0;
 }
 
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
 function uniqueJoin(values: string[]) {
   return Array.from(new Set(values.filter(Boolean))).join(" ");
 }
 
-function pickTheme(input: TikTokRadarPostIdeaInput) {
-  const text = [
+function buildSearchText(input: TikTokRadarPostIdeaInput) {
+  return [
     input.category,
     input.keyword,
     input.hook_text,
@@ -56,6 +64,10 @@ function pickTheme(input: TikTokRadarPostIdeaInput) {
   ]
     .filter(Boolean)
     .join(" ");
+}
+
+function pickTheme(input: TikTokRadarPostIdeaInput) {
+  const text = buildSearchText(input);
 
   if (text.includes("復縁") || text.includes("連絡")) {
     return {
@@ -121,6 +133,93 @@ function buildBaseHashtags(themeTag: string, keyword: string) {
   ]);
 }
 
+function calculateMuLeadScore(input: TikTokRadarPostIdeaInput, totalScore: number) {
+  const text = buildSearchText(input);
+  const hasMirrorHook =
+    text.includes("なんで") ||
+    text.includes("見抜") ||
+    text.includes("本当は") ||
+    text.includes("実は") ||
+    text.includes("気づいて");
+  const hasMuFit =
+    text.includes("相手の気持ち") ||
+    text.includes("自己否定") ||
+    text.includes("自分の価値") ||
+    text.includes("苦しい") ||
+    text.includes("不安");
+  const hasSaveSignal = text.includes("保存") || text.includes("見返す");
+
+  return clamp(totalScore + (hasMirrorHook ? 3 : 0) + (hasMuFit ? 3 : 0) + (hasSaveSignal ? 2 : 0), 0, 20);
+}
+
+function calculateViralFormatScore(input: TikTokRadarPostIdeaInput) {
+  const hook = cleanText(input.hook_text);
+  const caption = cleanText(input.caption_text);
+  const topComment = cleanText(input.top_comment);
+  const text = `${hook} ${caption} ${topComment}`;
+
+  const conciseHook = hook.length > 0 && hook.length <= 48;
+  const hasQuestion = /[？?]/.test(hook) || text.includes("なぜ") || text.includes("なんで");
+  const hasCommentSignal = topComment.length > 0;
+  const hasRepeatableFrame =
+    text.includes("特徴") ||
+    text.includes("サイン") ||
+    text.includes("理由") ||
+    text.includes("共通点") ||
+    text.includes("チェック");
+
+  return clamp(
+    2 +
+      (conciseHook ? 1 : 0) +
+      (hasQuestion ? 1 : 0) +
+      (hasCommentSignal ? 1 : 0) +
+      (hasRepeatableFrame ? 1 : 0),
+    0,
+    5
+  );
+}
+
+function pickRecommendedAction(muLeadScore: number, viralFormatScore: number, totalScore: number) {
+  if (muLeadScore >= 16 && viralFormatScore >= 4) {
+    return "今日の投稿候補。Mu導線型か見抜き型でそのまま台本化できます。";
+  }
+
+  if (muLeadScore >= 14) {
+    return "Mu導線向き。冒頭を短くして、最後にMu体験への一文を入れると使いやすいです。";
+  }
+
+  if (viralFormatScore >= 4 && totalScore >= 10) {
+    return "TikTok形式向き。保存型か共感型として調整すると使えます。";
+  }
+
+  if (totalScore >= 8) {
+    return "素材として保留。共鳴語を増やしてから投稿案化してください。";
+  }
+
+  return "市場メモとして保存。投稿化は急がず、似た素材を追加して比較してください。";
+}
+
+function buildSofiaStrategyNote({
+  themeName,
+  muLeadScore,
+  viralFormatScore,
+  totalScore,
+  recommendedAction,
+}: {
+  themeName: string;
+  muLeadScore: number;
+  viralFormatScore: number;
+  totalScore: number;
+  recommendedAction: string;
+}) {
+  return [
+    `Sofia戦略メモ: ${themeName}の素材です。`,
+    `共鳴合計 ${totalScore} / Mu導線 ${muLeadScore} / TikTok形式 ${viralFormatScore}。`,
+    recommendedAction,
+    "外向きのバズだけでなく、『これ私のことだ』『Muに聞きたい』へつながる言葉を優先してください。",
+  ].join("\n");
+}
+
 export function buildTikTokRadarPostIdea(
   input: TikTokRadarPostIdeaInput
 ): TikTokRadarPostIdea {
@@ -134,6 +233,17 @@ export function buildTikTokRadarPostIdea(
     scoreNumber(input.why_known_score) +
     scoreNumber(input.resonance_score) +
     scoreNumber(input.save_intent_score);
+
+  const muLeadScore = calculateMuLeadScore(input, totalScore);
+  const viralFormatScore = calculateViralFormatScore(input);
+  const recommendedAction = pickRecommendedAction(muLeadScore, viralFormatScore, totalScore);
+  const sofiaStrategyNote = buildSofiaStrategyNote({
+    themeName: theme.name,
+    muLeadScore,
+    viralFormatScore,
+    totalScore,
+    recommendedAction,
+  });
 
   const scoreLabel =
     totalScore >= 13
@@ -241,6 +351,10 @@ export function buildTikTokRadarPostIdea(
     hashtags,
     totalScore,
     scoreLabel,
+    muLeadScore,
+    viralFormatScore,
+    recommendedAction,
+    sofiaStrategyNote,
     variants,
   };
 }

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,10 @@
     {
       "path": "/api/cron/monthly-partner-credits",
       "schedule": "10 0 1 * *"
+    },
+    {
+      "path": "/api/cron/tiktok-radar-daily",
+      "schedule": "20 0 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Sofia 今日のレーダー dashboard to `/admin/tiktok-radar`
- Add Mu導線スコア, engagement rate display, top word rankings, and work feed
- Strengthen rule-based Sofia analysis with more reaction/resonance/save/Mu lead patterns
- Add strategy scores and Sofia推奨アクション to the post idea page
- Add daily keepalive/summary cron endpoint for `sofia-tiktok-radar`
- Schedule `/api/cron/tiktok-radar-daily` in `vercel.json`

## Notes
- No DB migration is required.
- New scores are computed from existing columns, so the existing `tiktok_market_research` table can keep working as-is.
- This is intended as an internal tool improvement, not an external productization step.

## Testing
- Not run here. Please run `pnpm typecheck` and `pnpm build` locally before merge.