### PR TITLE
Fix new conversation context leak

### DIFF
--- a/src/lib/iros/irosClient.ts
+++ b/src/lib/iros/irosClient.ts
@@ -73,6 +73,46 @@ function getCidFromLocation(): string | null {
   return sp.get('cid');
 }
 
+function sanitizeReplyExtraForTransport(extra: Json | undefined): Json | undefined {
+  if (!extra || typeof extra !== 'object' || Array.isArray(extra)) return extra;
+
+  const sanitized: Json = { ...extra };
+
+  // /reply は conversationId を正本にサーバ側で文脈を解決する。
+  // クライアントから前ターンの ctx/history 系を渡すと、新規会話でも残響が混入するため送らない。
+  for (const key of [
+    'ctxPack',
+    'historyForWriter',
+    'historyDigestV1',
+    'topicDigest',
+    'topicDigestV2',
+    'conversationLine',
+    'situationSummary',
+    'situationTopic',
+    'referenceTarget',
+    'resolvedAsk',
+    'memoryDelta',
+    'memoryDeltaSeed',
+    'intuitionCandidate',
+    'intuitionSeed',
+    'lastIrDiagnosis',
+    'diagnosisFollowup',
+    'diagnosisFollowupTargetLabel',
+    'screenshotDiagnosisContext',
+    'screenshotDiagnosisHintText',
+    'screenshotDiagnosisFollowup',
+    'relationshipAskTypeForHfw',
+  ]) {
+    delete sanitized[key];
+  }
+
+  if (sanitized.extra && typeof sanitized.extra === 'object' && !Array.isArray(sanitized.extra)) {
+    sanitized.extra = sanitizeReplyExtraForTransport(sanitized.extra as Json);
+  }
+
+  return sanitized;
+}
+
 // -------- 公開 API --------
 
 export async function irosReply(body: {
@@ -81,7 +121,7 @@ export async function irosReply(body: {
   modeHint?: string;
   extra?: Json;
 
-  // ✅追加
+  // 互換のため型には残すが、/reply には送らない。
   history?: unknown[];
 }): Promise<Json> {
   const cid = body.conversationId ?? getCidFromLocation();
@@ -94,10 +134,11 @@ export async function irosReply(body: {
     conversationId: cid,
     text,
     modeHint: body.modeHint,
-    extra: body.extra,
+    extra: sanitizeReplyExtraForTransport(body.extra),
 
-    // ✅追加
-    history: Array.isArray(body.history) ? body.history : undefined,
+    // ✅ /reply へは履歴を送らない。
+    // 新規conversationIdでも旧historyが混入すると、別会話の文脈へ誤爆するため。
+    history: undefined,
   };
 
   const res = await withAuthFetch('/api/agent/iros/reply', {

--- a/src/lib/iros/irosClient.ts
+++ b/src/lib/iros/irosClient.ts
@@ -113,6 +113,31 @@ function sanitizeReplyExtraForTransport(extra: Json | undefined): Json | undefin
   return sanitized;
 }
 
+function buildReplyTextForTransport(text: string): string {
+  const raw = String(text ?? '').trim();
+  if (!raw) return raw;
+
+  const compact = raw.replace(/[　\s]+/g, '');
+
+  const explicitlyDiagnosis =
+    /(スクショ診断|スクリーンショット診断|画像診断|screenshotdiagnosis|ir診断|ｉｒ診断|診断ID|この診断|その診断|前の診断|さっきの診断|診断結果|診断の続き)/iu.test(
+      raw
+    );
+
+  const plainRelationshipAdvice =
+    /(恋愛相談|好きな人|距離感|相手の気持ち|近づきたい|重くなる|離れていく|どう相手との距離|どう関わる)/u.test(
+      raw
+    );
+
+  // Pre-SEED 側には「相手の気持ち」などを診断参照と見なす広いガードがある。
+  // 明示診断ではない恋愛相談は、先頭に通常チャット指示を付けて診断分岐から外す。
+  if (plainRelationshipAdvice && !explicitlyDiagnosis && !compact.startsWith('通常チャット')) {
+    return `通常チャットです。過去の診断文脈は使わず、いまの相談文だけから見てください。\n\n${raw}`;
+  }
+
+  return raw;
+}
+
 // -------- 公開 API --------
 
 export async function irosReply(body: {
@@ -132,7 +157,7 @@ export async function irosReply(body: {
 
   const payload = {
     conversationId: cid,
-    text,
+    text: buildReplyTextForTransport(text),
     modeHint: body.modeHint,
     extra: sanitizeReplyExtraForTransport(body.extra),
 


### PR DESCRIPTION
## Summary
- Stop sending `history` from `src/lib/iros/irosClient.ts` to `/api/agent/iros/reply`.
- Strip carryover context fields from `extra` before transport, including `ctxPack`, `historyForWriter`, `referenceTarget`, `resolvedAsk`, diagnosis followup fields, screenshot diagnosis fields, memory delta, and intuition seed fields.

## Why
A new Mu conversation can still receive stale client-side context if `history` or ctxPack-like fields are carried in the request payload. This can cause Mu to treat a new question as a continuation of an older diagnosis or copywriting flow.

## Notes
This is the client-side first guard. A server-side `/reply` first-turn guard is still recommended as a second safety layer, especially inside `route.ts`, but this patch removes the known transport leak from this client path.