### PR TITLE
Bridge first imaginal diagnosis to flow seed

### DIFF
--- a/src/app/api/mu/first-diagnosis/route.ts
+++ b/src/app/api/mu/first-diagnosis/route.ts
@@ -13,10 +13,14 @@ import {
   enforceImaginalCopyFromIntention,
   type ImaginalIntentionLayer,
 } from '@/lib/iros/imaginal/imaginalCopySeed';
+import {
+  applyImaginalFlowSeed,
+  type ImaginalFlowSeedLike,
+} from '@/lib/iros/imaginal/imaginalFlowSeed';
 
 const sb = createClient(SUPABASE_URL, SERVICE_ROLE, { auth: { persistSession: false } });
 
-type ImaginalDiagnosisSeed = {
+type ImaginalDiagnosisSeed = ImaginalFlowSeedLike & {
   kind?: 'imaginal_first';
   imaginal_copy?: string;
   visible_wish?: string;
@@ -105,7 +109,6 @@ function normalizeImageType(value: unknown): ImaginalDiagnosisSeed['image_type']
   return 'other';
 }
 
-
 function normalizeIntentionLayer(value: unknown): ImaginalIntentionLayer | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
   const v = value as Record<string, unknown>;
@@ -119,11 +122,23 @@ function normalizeIntentionLayer(value: unknown): ImaginalIntentionLayer | undef
 
   return Object.values(layer).some(Boolean) ? layer : undefined;
 }
+
+function normalizeDiagnosisScope(value: unknown): ImaginalDiagnosisSeed['diagnosis_scope'] | undefined {
+  return String(value ?? '').trim() === 'current_imaginal' ? 'current_imaginal' : undefined;
+}
+
+function normalizeFlowPriority(value: unknown): true | undefined {
+  return value === true || String(value ?? '').trim() === 'true' ? true : undefined;
+}
+
 function buildDisplayText(seed: ImaginalDiagnosisSeed, fallback: string): string {
   const copy = cleanString(seed.imaginal_copy);
   if (!copy) return fallback;
 
   return [
+    'これは、画像をきっかけに見えた「今現在のイマジナル」です。',
+    '画像の内容そのものではなく、いま立ち上がっているフローをもとに見ています。',
+    '',
     'あなたのイマジナルコピー',
     copy,
     '',
@@ -167,6 +182,11 @@ function safeParseDiagnosis(raw: string): {
       word_reaction: cleanString(seedRaw?.word_reaction ?? seedRaw?.wordReaction),
       action_reaction: cleanString(seedRaw?.action_reaction ?? seedRaw?.actionReaction),
       intention_layer: normalizeIntentionLayer(seedRaw?.intention_layer ?? seedRaw?.intentionLayer),
+      diagnosis_scope: normalizeDiagnosisScope(seedRaw?.diagnosis_scope ?? seedRaw?.diagnosisScope),
+      flow_priority: normalizeFlowPriority(seedRaw?.flow_priority ?? seedRaw?.flowPriority),
+      image_seed: seedRaw?.image_seed ?? seedRaw?.imageSeed,
+      current_flow_input_seed: seedRaw?.current_flow_input_seed ?? seedRaw?.currentFlowInputSeed,
+      second_flow_input_seed: seedRaw?.second_flow_input_seed ?? seedRaw?.secondFlowInputSeed,
       dominant_field: normalizeDominantField(seedRaw?.dominant_field ?? seedRaw?.dominantField),
       creative_direction: cleanString(seedRaw?.creative_direction ?? seedRaw?.creativeDirection),
       today_step: cleanString(seedRaw?.today_step ?? seedRaw?.todayStep),
@@ -178,11 +198,15 @@ function safeParseDiagnosis(raw: string): {
         'Mu文体で返す',
         '説明調にしない',
         '相手の気持ちは断定しない',
+        '画像は補助として扱う',
+        '正本は今現在のフローと状態移管に置く',
         '画像から読み取れないことは言い切らない',
         'イマジナルコピーを正本として扱う',
         '創造の方向へ戻す',
       ],
     };
+
+    Object.assign(seed, applyImaginalFlowSeed(seed));
 
     const enforcedSeed = enforceImaginalCopyFromIntention(seed);
     seed.imaginal_copy = enforcedSeed.imaginal_copy;
@@ -262,6 +286,8 @@ async function logDiagnosis(params: {
       diagnosis_seed_json: {
         ...(params.diagnosisSeedJson ?? {}),
         kind: 'imaginal_first',
+        diagnosis_scope: 'current_imaginal',
+        flow_priority: true,
       },
     });
   } catch (e: any) {
@@ -373,18 +399,25 @@ export async function POST(req: NextRequest) {
 
     const system = [
       'あなたはMuverseの初回イマジナル診断を行うMuです。',
+      'これは画像診断ではなく、画像を入口にした「今現在のイマジナル」の状態観測です。',
+      '画像は補助入力です。正本は、ユーザーがその画像を選び、今ここに出した時点で立ち上がっているフローです。',
+      '画像の表面内容とフロー解釈が食い違う場合は、フロー解釈を優先してください。ただし、人格・運命・恒常的な未来として断定しないでください。',
+      'currentFlow は、今この画像を出した時点の現在状態として読んでください。secondFlow は、そこから移管しようとしている状態として読んでください。',
       'ユーザーが送った画像を見て、相手の気持ちや未来を断定するのではなく、ユーザーがいま見続けている未来の方向を読み取ってください。',
       '画像はLINEやDMとは限りません。メモ、ToDo、投稿文、告知文、メール、予定表、講座画面、Mu BOOKのページ、その他の気になる画面も対象です。',
       'OCR事前分類や会話スクショ判定は行いません。画像から読める範囲で、なぜその画面が気になっているのかを見ます。',
+      'まず image_seed に、画像の表面観測、見える言葉、見える行動、緊張点、ユーザーが反応している一点を入れてください。',
+      '次に current_flow_input_seed と second_flow_input_seed を作ってください。e_turn は e1/e2/e3/e4/e5、depthStage は S1〜T3、polarity は pos/neg だけを使ってください。',
+      'current_flow_input_seed は「今この画像を出した時点の現在状態」、second_flow_input_seed は「そこから移管しようとしている状態」です。',
       '必ず最初に「あなたのイマジナルコピー」として、その人だけの短いコピーを1つ生成してください。',
       'イマジナルコピーは、状況の要約ではありません。画像に写っている出来事をそのまま短く言い換えるだけのコピーは禁止です。',
       'イマジナルコピーは、表面の願いではなく、その人が先に置いてしまっている未来を映してください。',
-            '生成前に内部で、1.表面の出来事 2.言葉や行動に出ている反応 3.その出来事を何の意味として受け取っているか 4.その人が先に見ている未来 5.その未来が現実を引っ張る構造、の順に深めてください。',
+      '生成前に内部で、1.表面の出来事 2.この画像を出した現在状態 3.そこから移管しようとしている状態 4.その出来事を何の意味として受け取っているか 5.その人が先に見ている未来、の順に深めてください。',
       'imaginal_copy は必ず intention_layer.seen_future から生成してください。S層の状況説明、F層の感情説明、R層の関係説明、C層の行動説明をコピーにしてはいけません。',
       'intention_layer には received_meaning, seen_future, hidden_intention, future_distortion を入れてください。',
       'コピーには、会いたい・伝えたい・すれ違う・不安・寂しいなどの表面語をそのまま並べないでください。表面語を使う場合は、必ず一段深い構造に変換してください。',
-      '良い例: 「会えない事実で、自分の価値を測る未来」「約束の欠け目に、愛されなさを見ている」「話す前から、失われる側に立っている」「返事の遅さで、関係の終わりを先に見ている」。',
-      '悪い例: 「会いたいのに、伝えられずすれ違う未来」「不安なのに、言えない未来」「誤解を解きたいのに、距離ができる未来」。これは浅い状況要約なので避けてください。',
+      '良い例: 「返事待ちのベンチに、長居しすぎる未来」「相手の通知欄に、自分の時間まで置いてくる未来」「会えない事実で、自分の価値を測る未来」。',
+      '悪い例: 「会いたいのに、伝えられずすれ違う未来」「不安なのに、言えない未来」「確認の空白に、予定の主導権を握っている」。これは浅い状況要約なので避けてください。',
       '文字数は18〜42文字程度。短くてもよいですが、普通の恋愛診断・性格診断・状況要約に見えるコピーは禁止です。',
       '出力構成は、1.あなたのイマジナルコピー 2.いま見えている願い 3.見続けている未来 4.言葉に出ている反応 5.行動に出ている反応 6.創造の方向 7.今日の小さな一歩。',
       '相手の気持ちは断定しない。画像から読み取れないことは言い切らない。スピリチュアルな断定をしない。',
@@ -392,13 +425,14 @@ export async function POST(req: NextRequest) {
       '「寄り添います」「静かに」「本当の自分」「本当の姿」「言葉になる前」は使わないでください。',
       '出力はJSONのみ。Markdownや説明文を前後に付けないでください。',
       'JSONは display_text と seed を持つオブジェクトにしてください。',
-      'seedには kind, imaginal_copy, visible_wish, seen_future, word_reaction, action_reaction, intention_layer, dominant_field, creative_direction, today_step, image_type, evidence_points, uncertain_points, user_name_candidate, writer_directives を入れてください。',
-      'dominant_fieldは anxiety / comparison / destruction / creation / unknown のいずれか。image_typeは line_or_dm / email / memo / todo / post_draft / book_page / application_page / other のいずれか。',
+      'seedには kind, diagnosis_scope, flow_priority, image_seed, current_flow_input_seed, second_flow_input_seed, imaginal_copy, visible_wish, seen_future, word_reaction, action_reaction, intention_layer, dominant_field, creative_direction, today_step, image_type, evidence_points, uncertain_points, user_name_candidate, writer_directives を入れてください。',
+      'diagnosis_scope は current_imaginal、flow_priority は true にしてください。dominant_fieldは anxiety / comparison / destruction / creation / unknown のいずれか。image_typeは line_or_dm / email / memo / todo / post_draft / book_page / application_page / other のいずれか。',
       'display_textには内部キー名を出さず、自然な日本語で表示してください。全体で900文字以内。',
     ].join('\n');
 
     const userText = [
       'この画像から、初回イマジナル診断として読めることを返してください。',
+      '画像は補助として扱い、この画像を出した時点の currentFlow と、そこから移管しようとしている secondFlow を必ずSeedにしてください。',
       'ユーザーに見せる診断文 display_text と、本線Muへ引き継ぐ内部Seed seed を同時に作ってください。',
       note ? `補足メモ：${note}` : '',
     ].filter(Boolean).join('\n');

--- a/src/app/api/mu/first-diagnosis/route.ts
+++ b/src/app/api/mu/first-diagnosis/route.ts
@@ -137,7 +137,6 @@ function buildDisplayText(seed: ImaginalDiagnosisSeed, fallback: string): string
 
   return [
     'これは、画像をきっかけに見えた「今現在のイマジナル」です。',
-    '画像の内容そのものではなく、いま立ち上がっているフローをもとに見ています。',
     '',
     'あなたのイマジナルコピー',
     copy,

--- a/src/lib/iros/imaginal/imaginalFlowSeed.ts
+++ b/src/lib/iros/imaginal/imaginalFlowSeed.ts
@@ -1,0 +1,273 @@
+import { buildFlowEngineResult } from '@/lib/iros/flow/flowEngine';
+import {
+  buildHumanStateTransferSeed,
+  type HumanStateTransferSeed,
+  type SaPolarity,
+  type UtteranceAlignment,
+} from '@/lib/iros/delta/humanStateTransfer';
+
+export type ImaginalImageSeed = {
+  image_observation?: string;
+  visible_events?: string[];
+  visible_words?: string[];
+  visible_actions?: string[];
+  tension_points?: string[];
+  user_reaction_hook?: string;
+};
+
+export type ImaginalFlowInputSeed = {
+  e_turn?: 'e1' | 'e2' | 'e3' | 'e4' | 'e5';
+  depthStage?: string;
+  polarity?: 'pos' | 'neg';
+  confidence?: number;
+  phase?: 'Inner' | 'Outer';
+  sa?: number;
+  saPolarity?: SaPolarity;
+  yuragi?: number;
+  yohaku?: number;
+  utteranceAlignment?: UtteranceAlignment;
+  basedOn?: string;
+};
+
+export type ImaginalFlowBuiltSeed = {
+  version: 'imaginal_flow_seed_v1';
+  scope: 'current_imaginal';
+  flowPriority: true;
+  note: string;
+  currentFlow: string | null;
+  secondFlow: string | null;
+  currentShort: string | null;
+  secondShort: string | null;
+  currentBasedOn: string | null;
+  secondBasedOn: string | null;
+  transferSeed: HumanStateTransferSeed | null;
+  seedText: string | null;
+};
+
+export type ImaginalFlowSeedLike = {
+  diagnosis_scope?: 'current_imaginal';
+  flow_priority?: true;
+  image_seed?: ImaginalImageSeed;
+  current_flow_input_seed?: ImaginalFlowInputSeed;
+  second_flow_input_seed?: ImaginalFlowInputSeed;
+  imaginal_flow_seed?: ImaginalFlowBuiltSeed;
+};
+
+const FLOW_ENERGIES = ['e1', 'e2', 'e3', 'e4', 'e5'] as const;
+const FLOW_POLARITIES = ['pos', 'neg'] as const;
+const FLOW_STAGES = [
+  'S1', 'S2', 'S3',
+  'F1', 'F2', 'F3',
+  'R1', 'R2', 'R3',
+  'C1', 'C2', 'C3',
+  'I1', 'I2', 'I3',
+  'T1', 'T2', 'T3',
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function clean(value: unknown): string | undefined {
+  const s = String(value ?? '').trim();
+  return s || undefined;
+}
+
+function cleanArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const items = value
+    .map((item) => String(item ?? '').trim())
+    .filter(Boolean)
+    .slice(0, 8);
+  return items.length ? items : undefined;
+}
+
+function clamp01(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function normalizeEnergy(value: unknown): ImaginalFlowInputSeed['e_turn'] | undefined {
+  const v = clean(value);
+  return FLOW_ENERGIES.includes(v as any) ? (v as ImaginalFlowInputSeed['e_turn']) : undefined;
+}
+
+function normalizePolarity(value: unknown): ImaginalFlowInputSeed['polarity'] | undefined {
+  const v = clean(value);
+  return FLOW_POLARITIES.includes(v as any) ? (v as ImaginalFlowInputSeed['polarity']) : undefined;
+}
+
+function normalizeDepthStage(value: unknown): string | undefined {
+  const v = clean(value)?.toUpperCase();
+  return FLOW_STAGES.includes(v as any) ? v : undefined;
+}
+
+function normalizePhase(value: unknown): ImaginalFlowInputSeed['phase'] | undefined {
+  const v = clean(value);
+  if (v === 'Inner' || v === 'Outer') return v;
+  if (v?.toLowerCase() === 'inner') return 'Inner';
+  if (v?.toLowerCase() === 'outer') return 'Outer';
+  return undefined;
+}
+
+function normalizeSaPolarity(value: unknown): SaPolarity | undefined {
+  const v = clean(value);
+  if (v === 'pos' || v === 'neg' || v === 'neutral') return v;
+  return undefined;
+}
+
+function normalizeUtteranceAlignment(value: unknown): UtteranceAlignment | undefined {
+  const v = clean(value);
+  if (
+    v === 'aligned' ||
+    v === 'partially_aligned' ||
+    v === 'misaligned' ||
+    v === 'overstated' ||
+    v === 'understated'
+  ) {
+    return v;
+  }
+  return undefined;
+}
+
+export function normalizeImaginalImageSeed(value: unknown): ImaginalImageSeed | undefined {
+  if (!isRecord(value)) return undefined;
+  const seed: ImaginalImageSeed = {
+    image_observation: clean(value.image_observation ?? value.imageObservation),
+    visible_events: cleanArray(value.visible_events ?? value.visibleEvents),
+    visible_words: cleanArray(value.visible_words ?? value.visibleWords),
+    visible_actions: cleanArray(value.visible_actions ?? value.visibleActions),
+    tension_points: cleanArray(value.tension_points ?? value.tensionPoints),
+    user_reaction_hook: clean(value.user_reaction_hook ?? value.userReactionHook),
+  };
+  return Object.values(seed).some(Boolean) ? seed : undefined;
+}
+
+export function normalizeImaginalFlowInputSeed(value: unknown): ImaginalFlowInputSeed | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const polarity = normalizePolarity(value.polarity);
+  const seed: ImaginalFlowInputSeed = {
+    e_turn: normalizeEnergy(value.e_turn ?? value.eTurn ?? value.energy),
+    depthStage: normalizeDepthStage(value.depthStage ?? value.depth_stage ?? value.stage),
+    polarity,
+    confidence: clamp01(value.confidence),
+    phase: normalizePhase(value.phase),
+    sa: clamp01(value.sa),
+    saPolarity: normalizeSaPolarity(value.saPolarity ?? value.sa_polarity) ?? polarity,
+    yuragi: clamp01(value.yuragi),
+    yohaku: clamp01(value.yohaku),
+    utteranceAlignment: normalizeUtteranceAlignment(value.utteranceAlignment ?? value.utterance_alignment),
+    basedOn: clean(value.basedOn ?? value.based_on),
+  };
+
+  if (!seed.e_turn || !seed.depthStage || !seed.polarity) return undefined;
+  return seed;
+}
+
+export function buildImaginalFlowSeed(args: {
+  imageSeed?: ImaginalImageSeed;
+  currentInput?: ImaginalFlowInputSeed;
+  secondInput?: ImaginalFlowInputSeed;
+}): ImaginalFlowBuiltSeed | null {
+  const currentInput = args.currentInput;
+  const secondInput = args.secondInput;
+  if (!currentInput || !secondInput) return null;
+
+  try {
+    const current = buildFlowEngineResult({
+      current: {
+        e_turn: currentInput.e_turn,
+        depthStage: currentInput.depthStage as any,
+        polarity: currentInput.polarity,
+        confidence: currentInput.confidence ?? null,
+        phase: currentInput.phase ?? null,
+        sa: currentInput.sa ?? null,
+        yuragi: currentInput.yuragi ?? null,
+        yohaku: currentInput.yohaku ?? null,
+        basedOn: currentInput.basedOn ?? args.imageSeed?.user_reaction_hook ?? 'imaginal_image_current_state',
+      },
+      futureStagePool: ['I1', 'I2', 'I3'] as any,
+      futurePolarityPool: ['pos'] as any,
+    });
+
+    const second = buildFlowEngineResult({
+      current: {
+        e_turn: secondInput.e_turn,
+        depthStage: secondInput.depthStage as any,
+        polarity: secondInput.polarity,
+        confidence: secondInput.confidence ?? currentInput.confidence ?? null,
+        phase: secondInput.phase ?? currentInput.phase ?? null,
+        basedOn: secondInput.basedOn ?? 'imaginal_image_moving_state',
+      },
+      futureStagePool: ['I1', 'I2', 'I3'] as any,
+      futurePolarityPool: ['pos'] as any,
+    });
+
+    const currentFlow = current.currentFlow?.id ?? null;
+    const secondFlow = second.currentFlow?.id ?? null;
+
+    const transferSeed = buildHumanStateTransferSeed({
+      currentFlow,
+      secondFlow,
+      sa: currentInput.sa ?? null,
+      saPolarity: currentInput.saPolarity ?? currentInput.polarity ?? null,
+      yuragi: currentInput.yuragi ?? null,
+      yohaku: currentInput.yohaku ?? null,
+      utteranceAlignment: currentInput.utteranceAlignment ?? null,
+    });
+
+    const seedText = [
+      'IMAGINAL_FLOW_SEED (DO NOT OUTPUT):',
+      'scope=current_imaginal',
+      'image_is_auxiliary=true',
+      'flow_priority=true',
+      'rule=画像の表面説明ではなく、この画像を出した時点の現在状態と移管を正本にする。',
+      currentFlow ? `CURRENT_FLOW=${currentFlow}` : null,
+      secondFlow ? `SECOND_FLOW=${secondFlow}` : null,
+      transferSeed.seedText,
+    ].filter((v): v is string => Boolean(v)).join('\n').trim();
+
+    return {
+      version: 'imaginal_flow_seed_v1',
+      scope: 'current_imaginal',
+      flowPriority: true,
+      note: '画像は補助。正本は、この画像を出した時点の現在状態と、そこから移管しようとしている状態。',
+      currentFlow,
+      secondFlow,
+      currentShort: current.currentFlow?.short ?? null,
+      secondShort: second.currentFlow?.short ?? null,
+      currentBasedOn: current.currentFlow?.basedOn ?? null,
+      secondBasedOn: second.currentFlow?.basedOn ?? null,
+      transferSeed,
+      seedText,
+    };
+  } catch (error) {
+    console.warn('[imaginal-flow-seed] build skipped:', error);
+    return null;
+  }
+}
+
+export function applyImaginalFlowSeed<T extends ImaginalFlowSeedLike>(seed: T): T {
+  const imageSeed = normalizeImaginalImageSeed((seed as any).image_seed ?? (seed as any).imageSeed);
+  const currentInput = normalizeImaginalFlowInputSeed(
+    (seed as any).current_flow_input_seed ?? (seed as any).currentFlowInputSeed,
+  );
+  const secondInput = normalizeImaginalFlowInputSeed(
+    (seed as any).second_flow_input_seed ?? (seed as any).secondFlowInputSeed,
+  );
+
+  const imaginalFlowSeed = buildImaginalFlowSeed({ imageSeed, currentInput, secondInput });
+
+  return {
+    ...seed,
+    diagnosis_scope: 'current_imaginal',
+    flow_priority: true,
+    image_seed: imageSeed ?? seed.image_seed,
+    current_flow_input_seed: currentInput ?? seed.current_flow_input_seed,
+    second_flow_input_seed: secondInput ?? seed.second_flow_input_seed,
+    imaginal_flow_seed: imaginalFlowSeed ?? seed.imaginal_flow_seed,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `imaginalFlowSeed.ts` to normalize image observation, current flow input, and second flow input.
- Bridges first diagnosis seed into existing `flowEngine` and `humanStateTransfer`.
- Marks first diagnosis as `current_imaginal` with `flow_priority: true`.
- Updates first diagnosis prompt/display so the image is auxiliary and the current→second state transfer is treated as the source of truth.

## Notes
- This was edited through GitHub while local environment was unavailable.
- Please run `npm run typecheck` locally before merge.